### PR TITLE
Let local mcp proxy report tools for granular toggle active/inactive at tool level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metamcp/mcp-server-metamcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metamcp/mcp-server-metamcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.5.0",
@@ -57,9 +57,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamcp/mcp-server-metamcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP Server MetaMCP manages all your other MCPs in one MCP.",
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "tsc && shx chmod +x dist/*.js",
     "watch": "tsc --watch",
     "inspector": "dotenv -e .env.local npx @modelcontextprotocol/inspector dist/index.js -e METAMCP_API_KEY=${METAMCP_API_KEY} -e METAMCP_API_BASE_URL=${METAMCP_API_BASE_URL}",
-    "inspector:prod": "dotenv -e .env.production.local npx @modelcontextprotocol/inspector dist/index.js -e METAMCP_API_KEY=${METAMCP_API_KEY}"
+    "inspector:prod": "dotenv -e .env.production.local npx @modelcontextprotocol/inspector dist/index.js -e METAMCP_API_KEY=${METAMCP_API_KEY}",
+    "report": "dotenv -e .env.local -- node dist/index.js --report"
   },
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -40,7 +40,7 @@ export const createMetaMcpClient = (
   const client = new Client(
     {
       name: "MetaMCP",
-      version: "0.3.0",
+      version: "0.4.0",
     },
     {
       capabilities: {

--- a/src/fetch-capabilities.ts
+++ b/src/fetch-capabilities.ts
@@ -1,0 +1,73 @@
+import axios from "axios";
+import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
+
+export enum ProfileCapability {
+  TOOLS_MANAGEMENT = "TOOLS_MANAGEMENT",
+}
+
+let _capabilitiesCache: ProfileCapability[] | null = null;
+let _capabilitiesCacheTimestamp: number = 0;
+const CACHE_TTL_MS = 1000; // 1 second cache TTL
+
+export async function getProfileCapabilities(
+  forceRefresh: boolean = false
+): Promise<ProfileCapability[]> {
+  const currentTime = Date.now();
+  const cacheAge = currentTime - _capabilitiesCacheTimestamp;
+
+  // Use cache if it exists, is not null, and either:
+  // 1. forceRefresh is false, or
+  // 2. forceRefresh is true but cache is less than 1 second old
+  if (
+    _capabilitiesCache !== null &&
+    (!forceRefresh || cacheAge < CACHE_TTL_MS)
+  ) {
+    return _capabilitiesCache;
+  }
+
+  try {
+    const apiKey = getMetaMcpApiKey();
+    const apiBaseUrl = getMetaMcpApiBaseUrl();
+
+    if (!apiKey) {
+      console.error(
+        "METAMCP_API_KEY is not set. Please set it via environment variable or command line argument."
+      );
+      return _capabilitiesCache || [];
+    }
+
+    const headers = { Authorization: `Bearer ${apiKey}` };
+    const response = await axios.get(`${apiBaseUrl}/api/profile-capabilities`, {
+      headers,
+    });
+    const data = response.data;
+
+    // Access the 'profileCapabilities' array in the response
+    if (data && data.profileCapabilities) {
+      const capabilities = data.profileCapabilities
+        .map((capability: string) => {
+          // Map string to enum value if it exists, otherwise return undefined
+          return ProfileCapability[
+            capability as keyof typeof ProfileCapability
+          ];
+        })
+        .filter(
+          (
+            capability: ProfileCapability | undefined
+          ): capability is ProfileCapability => capability !== undefined
+        );
+
+      _capabilitiesCache = capabilities;
+      _capabilitiesCacheTimestamp = currentTime;
+      return capabilities;
+    }
+
+    return _capabilitiesCache || [];
+  } catch (error) {
+    // Return empty array if API doesn't exist or has errors
+    if (_capabilitiesCache !== null) {
+      return _capabilitiesCache;
+    }
+    return [];
+  }
+}

--- a/src/fetch-tools.ts
+++ b/src/fetch-tools.ts
@@ -1,0 +1,78 @@
+import axios from "axios";
+import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
+
+enum ToolStatus {
+  ACTIVE = "ACTIVE",
+  INACTIVE = "INACTIVE",
+}
+
+// Define interface for tool parameters with only required fields
+export interface ToolParameters {
+  mcp_server_uuid: string;
+  name: string;
+  status: ToolStatus;
+}
+
+let _toolsCache: Record<string, ToolParameters> | null = null;
+let _toolsCacheTimestamp: number = 0;
+const CACHE_TTL_MS = 1000; // 1 second cache TTL
+
+export async function getInactiveTools(
+  forceRefresh: boolean = false
+): Promise<Record<string, ToolParameters>> {
+  const currentTime = Date.now();
+  const cacheAge = currentTime - _toolsCacheTimestamp;
+
+  // Use cache if it exists, is not null, and either:
+  // 1. forceRefresh is false, or
+  // 2. forceRefresh is true but cache is less than 1 second old
+  if (_toolsCache !== null && (!forceRefresh || cacheAge < CACHE_TTL_MS)) {
+    return _toolsCache;
+  }
+
+  try {
+    const apiKey = getMetaMcpApiKey();
+    const apiBaseUrl = getMetaMcpApiBaseUrl();
+
+    if (!apiKey) {
+      console.error(
+        "METAMCP_API_KEY is not set. Please set it via environment variable or command line argument."
+      );
+      return _toolsCache || {};
+    }
+
+    const headers = { Authorization: `Bearer ${apiKey}` };
+    const response = await axios.get(
+      `${apiBaseUrl}/api/tools?status=${ToolStatus.INACTIVE}`,
+      {
+        headers,
+      }
+    );
+    const data = response.data;
+
+    const toolDict: Record<string, ToolParameters> = {};
+    // Access the 'results' array in the response
+    if (data && data.results) {
+      for (const tool of data.results) {
+        const params: ToolParameters = {
+          mcp_server_uuid: tool.mcp_server_uuid,
+          name: tool.name,
+          status: tool.status,
+        };
+
+        const uniqueId = `${tool.mcp_server_uuid}:${tool.name}`;
+        toolDict[uniqueId] = params;
+      }
+    }
+
+    _toolsCache = toolDict;
+    _toolsCacheTimestamp = currentTime;
+    return toolDict;
+  } catch (error) {
+    // Return empty object if API doesn't exist or has errors
+    if (_toolsCache !== null) {
+      return _toolsCache;
+    }
+    return {};
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./mcp-proxy.js";
 import { Command } from "commander";
+import { reportAllTools } from "./report-tools.js";
+import { cleanupAllSessions } from "./sessions.js";
 
 const program = new Command();
 
@@ -17,6 +19,10 @@ program
     "--metamcp-api-base-url <url>",
     "Base URL for MetaMCP API (can also be set via METAMCP_API_BASE_URL env var)"
   )
+  .option(
+    "--report",
+    "Fetch all MCPs, initialize clients, and report tools to MetaMCP API"
+  )
   .parse(process.argv);
 
 const options = program.opts();
@@ -30,7 +36,15 @@ if (options.metamcpApiBaseUrl) {
 }
 
 async function main() {
+  // If --report flag is set, run the reporting function instead of starting the server
+  if (options.report) {
+    await reportAllTools();
+    await cleanupAllSessions();
+    return;
+  }
+
   const transport = new StdioServerTransport();
+
   const { server, cleanup } = await createServer();
 
   await server.connect(transport);

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -38,7 +38,7 @@ export const createServer = async () => {
   const server = new Server(
     {
       name: "MetaMCP",
-      version: "0.3.0",
+      version: "0.4.0",
     },
     {
       capabilities: {

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -18,13 +18,11 @@ import {
   GetPromptResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import * as eventsource from "eventsource";
 import { getMcpServers } from "./fetch-metamcp.js";
 import { getSessionKey, sanitizeName } from "./utils.js";
 import { cleanupAllSessions, getSession } from "./sessions.js";
 import { ConnectedClient } from "./client.js";
-
-global.EventSource = eventsource.EventSource;
+import { reportToolsToMetaMcp } from "./report-tools.js";
 
 const toolToClient: Record<string, ConnectedClient> = {};
 const promptToClient: Record<string, ConnectedClient> = {};
@@ -80,6 +78,16 @@ export const createServer = async () => {
                 description: `[${serverName}] ${tool.description || ""}`,
               };
             }) || [];
+
+          // Report tools for this server
+          reportToolsToMetaMcp(
+            result.tools?.map((tool) => ({
+              name: tool.name,
+              description: tool.description,
+              toolSchema: tool.inputSchema,
+              mcp_server_uuid: uuid,
+            }))
+          );
 
           allTools.push(...toolsWithSource);
         } catch (error) {

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -20,7 +20,7 @@ import {
 import { z } from "zod";
 import { getMcpServers } from "./fetch-metamcp.js";
 import { getSessionKey, sanitizeName } from "./utils.js";
-import { cleanupAllSessions, getSession } from "./sessions.js";
+import { cleanupAllSessions, getSession, initSessions } from "./sessions.js";
 import { ConnectedClient } from "./client.js";
 import { reportToolsToMetaMcp } from "./report-tools.js";
 
@@ -42,6 +42,9 @@ export const createServer = async () => {
       },
     }
   );
+
+  // Initialize sessions in the background when server starts
+  initSessions().catch();
 
   // List Tools Handler
   server.setRequestHandler(ListToolsRequestSchema, async (request) => {

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -90,7 +90,7 @@ export const createServer = async () => {
               toolSchema: tool.inputSchema,
               mcp_server_uuid: uuid,
             }))
-          );
+          ).catch();
 
           allTools.push(...toolsWithSource);
         } catch (error) {

--- a/src/report-tools.ts
+++ b/src/report-tools.ts
@@ -1,0 +1,112 @@
+import axios from "axios";
+import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
+
+// Define interface for tool data structure
+export interface MetaMcpTool {
+  name: string;
+  description?: string;
+  toolSchema: any;
+  mcp_server_uuid: string;
+}
+
+// API route handler for submitting tools to MetaMCP
+export async function reportToolsToMetaMcp(tools: MetaMcpTool[]) {
+  try {
+    const apiKey = getMetaMcpApiKey();
+    const apiBaseUrl = getMetaMcpApiBaseUrl();
+
+    if (!apiKey) {
+      console.error(
+        "METAMCP_API_KEY is not set. Please set it via environment variable or command line argument."
+      );
+      return { error: "API key not set" };
+    }
+
+    // Validate that tools is an array
+    if (!Array.isArray(tools) || tools.length === 0) {
+      return {
+        error: "Request must include a non-empty array of tools",
+        status: 400,
+      };
+    }
+
+    // Validate required fields for all tools and prepare for submission
+    const validTools = [];
+    const errors = [];
+
+    for (const tool of tools) {
+      const { name, description, toolSchema, mcp_server_uuid } = tool;
+
+      // Validate required fields for each tool
+      if (!name || !toolSchema || !mcp_server_uuid) {
+        errors.push({
+          tool,
+          error:
+            "Missing required fields: name, toolSchema, or mcp_server_uuid",
+        });
+        continue;
+      }
+
+      validTools.push({
+        name,
+        description,
+        toolSchema,
+        mcp_server_uuid,
+      });
+    }
+
+    // Submit valid tools to MetaMCP API
+    let results: any[] = [];
+    if (validTools.length > 0) {
+      try {
+        const response = await axios.post(
+          `${apiBaseUrl}/api/tools`,
+          { tools: validTools },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${apiKey}`,
+            },
+          }
+        );
+
+        results = response.data.results || [];
+      } catch (error: any) {
+        if (error.response) {
+          // The request was made and the server responded with a status code outside of 2xx
+          return {
+            error: error.response.data.error || "Failed to submit tools",
+            status: error.response.status,
+            details: error.response.data,
+          };
+        } else if (error.request) {
+          // The request was made but no response was received
+          return {
+            error: "No response received from server",
+            details: error.request,
+          };
+        } else {
+          // Something happened in setting up the request
+          return {
+            error: "Error setting up request",
+            details: error.message,
+          };
+        }
+      }
+    }
+
+    return {
+      results,
+      errors,
+      success: results.length > 0,
+      failureCount: errors.length,
+      successCount: results.length,
+    };
+  } catch (error: any) {
+    console.error(error);
+    return {
+      error: "Failed to process tools request",
+      status: 500,
+    };
+  }
+}

--- a/src/report-tools.ts
+++ b/src/report-tools.ts
@@ -16,9 +16,6 @@ export async function reportToolsToMetaMcp(tools: MetaMcpTool[]) {
     const apiBaseUrl = getMetaMcpApiBaseUrl();
 
     if (!apiKey) {
-      console.error(
-        "METAMCP_API_KEY is not set. Please set it via environment variable or command line argument."
-      );
       return { error: "API key not set" };
     }
 
@@ -103,7 +100,6 @@ export async function reportToolsToMetaMcp(tools: MetaMcpTool[]) {
       successCount: results.length,
     };
   } catch (error: any) {
-    console.error(error);
     return {
       error: "Failed to process tools request",
       status: 500,

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,9 +1,10 @@
-import { ServerParameters } from "./fetch-metamcp.js";
+import { getMcpServers, ServerParameters } from "./fetch-metamcp.js";
 import {
   ConnectedClient,
   createMetaMcpClient,
   connectMetaMcpClient,
 } from "./client.js";
+import { getSessionKey } from "./utils.js";
 
 const _sessions: Record<string, ConnectedClient> = {};
 
@@ -41,6 +42,19 @@ export const getSession = async (
 
     return newClient;
   }
+};
+
+export const initSessions = async (): Promise<void> => {
+  const serverParams = await getMcpServers(true);
+
+  await Promise.allSettled(
+    Object.entries(serverParams).map(async ([uuid, params]) => {
+      const sessionKey = getSessionKey(uuid, params);
+      try {
+        await getSession(sessionKey, uuid, params);
+      } catch (error) {}
+    })
+  );
 };
 
 export const cleanupAllSessions = async (): Promise<void> => {


### PR DESCRIPTION
- Added `--report` flag, when run with this flag instead of starting the mcp server, report tools to MetaMCP app.
- Check if MetaMCP app's workspace(profile) enables capability of Tool Management. If so, hide inactive tools when routing tool calls.
- Initialize mcp server sessions at startup asyncly to cache earlier.