### PR TITLE
Send tool execution logs if MetaMCP app side allows it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metamcp/mcp-server-metamcp",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metamcp/mcp-server-metamcp",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamcp/mcp-server-metamcp",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "MCP Server MetaMCP manages all your other MCPs in one MCP.",
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,7 @@ export const createMetaMcpClient = (
   const client = new Client(
     {
       name: "MetaMCP",
-      version: "0.4.4",
+      version: "0.4.5",
     },
     {
       capabilities: {

--- a/src/fetch-capabilities.ts
+++ b/src/fetch-capabilities.ts
@@ -3,6 +3,7 @@ import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
 
 export enum ProfileCapability {
   TOOLS_MANAGEMENT = "TOOLS_MANAGEMENT",
+  TOOLS_LOG = "TOOLS_LOG",
 }
 
 let _capabilitiesCache: ProfileCapability[] | null = null;

--- a/src/fetch-capabilities.ts
+++ b/src/fetch-capabilities.ts
@@ -3,7 +3,7 @@ import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
 
 export enum ProfileCapability {
   TOOLS_MANAGEMENT = "TOOLS_MANAGEMENT",
-  TOOLS_LOG = "TOOLS_LOG",
+  TOOL_LOGS = "TOOL_LOGS",
 }
 
 let _capabilitiesCache: ProfileCapability[] | null = null;

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -218,7 +218,9 @@ export const createServer = async () => {
 
       // Update log with success result only if TOOL_LOGS capability is present
       if (hasToolsLogCapability && logId) {
-        await toolLogManager.completeLog(logId, result, executionTime);
+        try {
+          await toolLogManager.completeLog(logId, result, executionTime);
+        } catch (logError) {}
       }
 
       return result;
@@ -227,11 +229,13 @@ export const createServer = async () => {
 
       // Update log with error only if TOOL_LOGS capability is present
       if (hasToolsLogCapability && logId) {
-        await toolLogManager.failLog(
-          logId,
-          error.message || "Unknown error",
-          executionTime
-        );
+        try {
+          await toolLogManager.failLog(
+            logId,
+            error.message || "Unknown error",
+            executionTime
+          );
+        } catch (logError) {}
       }
 
       console.error(

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -180,13 +180,13 @@ export const createServer = async () => {
       throw new Error(`Tool is inactive: ${name}`);
     }
 
-    // Check if TOOLS_LOG capability is enabled
+    // Check if TOOL_LOGS capability is enabled
     const hasToolsLogCapability = profileCapabilities.includes(
-      ProfileCapability.TOOLS_LOG
+      ProfileCapability.TOOL_LOGS
     );
 
     try {
-      // Create initial pending log only if TOOLS_LOG capability is present
+      // Create initial pending log only if TOOL_LOGS capability is present
       if (hasToolsLogCapability) {
         const log = await toolLogManager.createLog(
           originalToolName,
@@ -216,7 +216,7 @@ export const createServer = async () => {
 
       const executionTime = Date.now() - startTime;
 
-      // Update log with success result only if TOOLS_LOG capability is present
+      // Update log with success result only if TOOL_LOGS capability is present
       if (hasToolsLogCapability && logId) {
         await toolLogManager.completeLog(logId, result, executionTime);
       }
@@ -225,7 +225,7 @@ export const createServer = async () => {
     } catch (error: any) {
       const executionTime = Date.now() - startTime;
 
-      // Update log with error only if TOOLS_LOG capability is present
+      // Update log with error only if TOOL_LOGS capability is present
       if (hasToolsLogCapability && logId) {
         await toolLogManager.failLog(
           logId,

--- a/src/mcp-proxy.ts
+++ b/src/mcp-proxy.ts
@@ -40,7 +40,7 @@ export const createServer = async () => {
   const server = new Server(
     {
       name: "MetaMCP",
-      version: "0.4.4",
+      version: "0.4.5",
     },
     {
       capabilities: {

--- a/src/tool-logs.ts
+++ b/src/tool-logs.ts
@@ -214,7 +214,6 @@ export class ToolLogManager {
 export async function reportToolExecutionLog(
   logData: ToolExecutionLog
 ): Promise<ToolLogResponse> {
-  console.error("reportToolExecutionLog", logData);
   try {
     // Check for TOOL_LOGS capability first
     const profileCapabilities = await getProfileCapabilities();

--- a/src/tool-logs.ts
+++ b/src/tool-logs.ts
@@ -1,0 +1,373 @@
+import axios from "axios";
+import { getMetaMcpApiBaseUrl, getMetaMcpApiKey } from "./utils.js";
+
+// Define status enum for tool execution
+export enum ToolExecutionStatus {
+  SUCCESS = "SUCCESS",
+  ERROR = "ERROR",
+  PENDING = "PENDING",
+}
+
+// Define interface for tool execution log data
+export interface ToolExecutionLog {
+  id?: string;
+  tool_name: string;
+  payload: any;
+  status: ToolExecutionStatus;
+  result?: any;
+  mcp_server_uuid: string;
+  error_message?: string | null;
+  execution_time_ms: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+// Response interfaces
+export interface ToolLogResponse {
+  id?: string;
+  success: boolean;
+  data?: any;
+  error?: string;
+  status?: number;
+  details?: any;
+}
+
+// Class to manage tool execution logs
+export class ToolLogManager {
+  private static instance: ToolLogManager;
+  private logStore: Map<string, ToolExecutionLog> = new Map();
+
+  private constructor() {}
+
+  public static getInstance(): ToolLogManager {
+    if (!ToolLogManager.instance) {
+      ToolLogManager.instance = new ToolLogManager();
+    }
+    return ToolLogManager.instance;
+  }
+
+  /**
+   * Creates a new tool execution log
+   * @param toolName Name of the tool
+   * @param serverUuid UUID of the MCP server
+   * @param payload The input parameters for the tool
+   * @returns Log object with tracking ID
+   */
+  public async createLog(
+    toolName: string,
+    serverUuid: string,
+    payload: any
+  ): Promise<ToolExecutionLog> {
+    // Generate a temporary ID for tracking
+    const tempId = `${Date.now()}-${Math.random()
+      .toString(36)
+      .substring(2, 9)}`;
+
+    const log: ToolExecutionLog = {
+      id: tempId, // Will be replaced with the real ID from the API
+      tool_name: toolName,
+      mcp_server_uuid: serverUuid,
+      payload,
+      status: ToolExecutionStatus.PENDING,
+      execution_time_ms: 0,
+      created_at: new Date().toISOString(),
+    };
+
+    // Store in memory
+    this.logStore.set(tempId, log);
+
+    // Submit to API
+    const response = await reportToolExecutionLog(log);
+
+    // Update with real ID if available
+    if (response.success && response.data?.id) {
+      const newId = response.data.id;
+      log.id = newId;
+      this.logStore.delete(tempId);
+      this.logStore.set(newId, log);
+    }
+
+    return log;
+  }
+
+  /**
+   * Updates the status of a tool execution log
+   * @param logId ID of the log to update
+   * @param status New status
+   * @param result Optional result data
+   * @param errorMessage Optional error message
+   * @param executionTimeMs Optional execution time in milliseconds
+   * @returns Updated log
+   */
+  public async updateLogStatus(
+    logId: string,
+    status: ToolExecutionStatus,
+    result?: any,
+    errorMessage?: string | null,
+    executionTimeMs?: number
+  ): Promise<ToolExecutionLog | null> {
+    const log = this.logStore.get(logId);
+
+    if (!log) {
+      console.error(`Cannot update log: Log with ID ${logId} not found`);
+      return null;
+    }
+
+    // Update log properties
+    log.status = status;
+    if (result !== undefined) log.result = result;
+    if (errorMessage !== undefined) log.error_message = errorMessage;
+    if (executionTimeMs !== undefined) log.execution_time_ms = executionTimeMs;
+    log.updated_at = new Date().toISOString();
+
+    // Update in memory
+    this.logStore.set(logId, log);
+
+    // Send update to API
+    await updateToolExecutionLog(logId, {
+      status,
+      result,
+      error_message: errorMessage,
+      execution_time_ms: executionTimeMs,
+    });
+
+    return log;
+  }
+
+  /**
+   * Get a log by ID
+   * @param logId ID of the log
+   * @returns Log or null if not found
+   */
+  public getLog(logId: string): ToolExecutionLog | null {
+    return this.logStore.get(logId) || null;
+  }
+
+  /**
+   * Complete the tool execution log with success status
+   * @param logId ID of the log to complete
+   * @param result Result data
+   * @param executionTimeMs Execution time in milliseconds
+   * @returns Updated log
+   */
+  public async completeLog(
+    logId: string,
+    result: any,
+    executionTimeMs: number
+  ): Promise<ToolExecutionLog | null> {
+    return this.updateLogStatus(
+      logId,
+      ToolExecutionStatus.SUCCESS,
+      result,
+      null,
+      executionTimeMs
+    );
+  }
+
+  /**
+   * Mark the tool execution log as failed
+   * @param logId ID of the log to fail
+   * @param errorMessage Error message
+   * @param executionTimeMs Execution time in milliseconds
+   * @returns Updated log
+   */
+  public async failLog(
+    logId: string,
+    errorMessage: string,
+    executionTimeMs: number
+  ): Promise<ToolExecutionLog | null> {
+    return this.updateLogStatus(
+      logId,
+      ToolExecutionStatus.ERROR,
+      null,
+      errorMessage,
+      executionTimeMs
+    );
+  }
+}
+
+/**
+ * Reports a tool execution log to the MetaMCP API
+ * @param logData The tool execution log data
+ * @returns Result of the API call
+ */
+export async function reportToolExecutionLog(
+  logData: ToolExecutionLog
+): Promise<ToolLogResponse> {
+  try {
+    const apiKey = getMetaMcpApiKey();
+    const apiBaseUrl = getMetaMcpApiBaseUrl();
+
+    if (!apiKey) {
+      return { success: false, error: "API key not set" };
+    }
+
+    // Validate required fields
+    if (!logData.tool_name || !logData.mcp_server_uuid) {
+      return {
+        success: false,
+        error: "Missing required fields: tool_name or mcp_server_uuid",
+        status: 400,
+      };
+    }
+
+    // Submit log to MetaMCP API
+    try {
+      const response = await axios.post(
+        `${apiBaseUrl}/api/tool-execution-logs`,
+        logData,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+          },
+        }
+      );
+
+      return {
+        success: true,
+        data: response.data,
+      };
+    } catch (error: any) {
+      if (error.response) {
+        // The request was made and the server responded with a status code outside of 2xx
+        return {
+          success: false,
+          error:
+            error.response.data.error || "Failed to submit tool execution log",
+          status: error.response.status,
+          details: error.response.data,
+        };
+      } else if (error.request) {
+        // The request was made but no response was received
+        return {
+          success: false,
+          error: "No response received from server",
+          details: error.request,
+        };
+      } else {
+        // Something happened in setting up the request
+        return {
+          success: false,
+          error: "Error setting up request",
+          details: error.message,
+        };
+      }
+    }
+  } catch (error: any) {
+    return {
+      success: false,
+      error: "Failed to process tool execution log request",
+      status: 500,
+      details: error.message,
+    };
+  }
+}
+
+/**
+ * Updates an existing tool execution log
+ * @param logId The ID of the log to update
+ * @param updateData The updated log data
+ * @returns Result of the API call
+ */
+export async function updateToolExecutionLog(
+  logId: string,
+  updateData: Partial<ToolExecutionLog>
+): Promise<ToolLogResponse> {
+  try {
+    const apiKey = getMetaMcpApiKey();
+    const apiBaseUrl = getMetaMcpApiBaseUrl();
+
+    if (!apiKey) {
+      return { success: false, error: "API key not set" };
+    }
+
+    if (!logId) {
+      return {
+        success: false,
+        error: "Log ID is required for updates",
+      };
+    }
+
+    // Submit update to MetaMCP API
+    try {
+      const response = await axios.put(
+        `${apiBaseUrl}/api/tool-execution-logs/${logId}`,
+        updateData,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+          },
+        }
+      );
+
+      return {
+        success: true,
+        data: response.data,
+      };
+    } catch (error: any) {
+      if (error.response) {
+        return {
+          success: false,
+          error:
+            error.response.data.error || "Failed to update tool execution log",
+          status: error.response.status,
+          details: error.response.data,
+        };
+      } else if (error.request) {
+        return {
+          success: false,
+          error: "No response received from server",
+          details: error.request,
+        };
+      } else {
+        return {
+          success: false,
+          error: "Error setting up request",
+          details: error.message,
+        };
+      }
+    }
+  } catch (error: any) {
+    return {
+      success: false,
+      error: "Failed to process update request",
+      status: 500,
+      details: error.message,
+    };
+  }
+}
+
+/**
+ * Simple function to log a tool execution
+ * @param toolName Name of the tool
+ * @param serverUuid UUID of the MCP server
+ * @param payload The input parameters for the tool
+ * @param result The result of the tool execution
+ * @param status Status of the execution
+ * @param errorMessage Optional error message if execution failed
+ * @param executionTimeMs Time taken to execute the tool in milliseconds
+ * @returns Result of the API call
+ */
+export async function logToolExecution(
+  toolName: string,
+  serverUuid: string,
+  payload: any,
+  result: any = null,
+  status: ToolExecutionStatus = ToolExecutionStatus.SUCCESS,
+  errorMessage: string | null = null,
+  executionTimeMs: number = 0
+): Promise<ToolLogResponse> {
+  const logData: ToolExecutionLog = {
+    tool_name: toolName,
+    mcp_server_uuid: serverUuid,
+    payload,
+    status,
+    result,
+    error_message: errorMessage,
+    execution_time_ms: executionTimeMs,
+  };
+
+  return await reportToolExecutionLog(logData);
+}

--- a/src/tool-logs.ts
+++ b/src/tool-logs.ts
@@ -62,10 +62,10 @@ export class ToolLogManager {
     serverUuid: string,
     payload: any
   ): Promise<ToolExecutionLog> {
-    // Check for TOOLS_LOG capability first
+    // Check for TOOL_LOGS capability first
     const profileCapabilities = await getProfileCapabilities();
     const hasToolsLogCapability = profileCapabilities.includes(
-      ProfileCapability.TOOLS_LOG
+      ProfileCapability.TOOL_LOGS
     );
 
     // Generate a temporary ID for tracking
@@ -86,7 +86,7 @@ export class ToolLogManager {
     // Store in memory
     this.logStore.set(tempId, log);
 
-    // Submit to API only if TOOLS_LOG capability is present
+    // Submit to API only if TOOL_LOGS capability is present
     if (hasToolsLogCapability) {
       const response = await reportToolExecutionLog(log);
 
@@ -135,13 +135,13 @@ export class ToolLogManager {
     // Update in memory
     this.logStore.set(logId, log);
 
-    // Check for TOOLS_LOG capability before sending update to API
+    // Check for TOOL_LOGS capability before sending update to API
     const profileCapabilities = await getProfileCapabilities();
     const hasToolsLogCapability = profileCapabilities.includes(
-      ProfileCapability.TOOLS_LOG
+      ProfileCapability.TOOL_LOGS
     );
 
-    // Send update to API only if TOOLS_LOG capability is present
+    // Send update to API only if TOOL_LOGS capability is present
     if (hasToolsLogCapability) {
       await updateToolExecutionLog(logId, {
         status,
@@ -214,15 +214,16 @@ export class ToolLogManager {
 export async function reportToolExecutionLog(
   logData: ToolExecutionLog
 ): Promise<ToolLogResponse> {
+  console.error("reportToolExecutionLog", logData);
   try {
-    // Check for TOOLS_LOG capability first
+    // Check for TOOL_LOGS capability first
     const profileCapabilities = await getProfileCapabilities();
     const hasToolsLogCapability = profileCapabilities.includes(
-      ProfileCapability.TOOLS_LOG
+      ProfileCapability.TOOL_LOGS
     );
 
     if (!hasToolsLogCapability) {
-      return { success: false, error: "TOOLS_LOG capability not enabled" };
+      return { success: false, error: "TOOL_LOGS capability not enabled" };
     }
 
     const apiKey = getMetaMcpApiKey();
@@ -305,14 +306,14 @@ export async function updateToolExecutionLog(
   updateData: Partial<ToolExecutionLog>
 ): Promise<ToolLogResponse> {
   try {
-    // Check for TOOLS_LOG capability first
+    // Check for TOOL_LOGS capability first
     const profileCapabilities = await getProfileCapabilities();
     const hasToolsLogCapability = profileCapabilities.includes(
-      ProfileCapability.TOOLS_LOG
+      ProfileCapability.TOOL_LOGS
     );
 
     if (!hasToolsLogCapability) {
-      return { success: false, error: "TOOLS_LOG capability not enabled" };
+      return { success: false, error: "TOOL_LOGS capability not enabled" };
     }
 
     const apiKey = getMetaMcpApiKey();
@@ -399,14 +400,14 @@ export async function logToolExecution(
   errorMessage: string | null = null,
   executionTimeMs: number = 0
 ): Promise<ToolLogResponse> {
-  // Check for TOOLS_LOG capability first
+  // Check for TOOL_LOGS capability first
   const profileCapabilities = await getProfileCapabilities();
   const hasToolsLogCapability = profileCapabilities.includes(
-    ProfileCapability.TOOLS_LOG
+    ProfileCapability.TOOL_LOGS
   );
 
   if (!hasToolsLogCapability) {
-    return { success: false, error: "TOOLS_LOG capability not enabled" };
+    return { success: false, error: "TOOL_LOGS capability not enabled" };
   }
 
   const logData: ToolExecutionLog = {


### PR DESCRIPTION
This feature is gated by TOOL_LOGS capability sent from your MetaMCP host, so no worries of leaking data.